### PR TITLE
Fixed GET request - remove body

### DIFF
--- a/Connection/Handler/RequestSerializationHandler.php
+++ b/Connection/Handler/RequestSerializationHandler.php
@@ -61,7 +61,7 @@ class RequestSerializationHandler
             unset($request['query_params']);
         }
 
-        if (!empty($body)) {
+        if (!empty($body) && 'GET' !== $request['http_method']) {
             ksort($body);
             $request['body'] = $this->serializer->serialize($body);
         }

--- a/Serializer/SmartSerializer.php
+++ b/Serializer/SmartSerializer.php
@@ -115,7 +115,7 @@ class SmartSerializer implements SerializerInterface
             return '';
         }
 
-        $result = @json_decode($data, true);
+        $result = json_decode($data, true);
 
         if (JSON_ERROR_NONE !== json_last_error() && E_NOTICE === (error_reporting() & E_NOTICE)) {
             throw new JsonErrorException(json_last_error(), $data, $result);

--- a/Tests/Unit/Connection/Handler/RequestSerializationHandlerTest.php
+++ b/Tests/Unit/Connection/Handler/RequestSerializationHandlerTest.php
@@ -39,10 +39,10 @@ class RequestSerializationHandlerTest extends TestCase
     public function requestDataProvider()
     {
         $data = [
-            [['body' => ['foo' => 'bar']], '{"foo":"bar"}'],
-            [['query_params' => ['foo' => 'bar']], '{"foo":"bar"}'],
-            [['body' => ['foo' => 'bar'], 'query_params' => ['foo' => 'bar']], '{"foo":"bar"}'],
-            [['body' => ['foo1' => 'bar1'], 'query_params' => ['foo2' => 'bar2']], '{"foo1":"bar1","foo2":"bar2"}'],
+            [['http_method' => 'POST', 'body' => ['foo' => 'bar']], '{"foo":"bar"}'],
+            [['http_method' => 'GET', 'query_params' => ['foo' => 'bar']], null],
+            [['http_method' => 'POST', 'body' => ['foo' => 'bar'], 'query_params' => ['foo' => 'bar']], '{"foo":"bar"}'],
+            [['http_method' => 'POST', 'body' => ['foo1' => 'bar1'], 'query_params' => ['foo2' => 'bar2']], '{"foo1":"bar1","foo2":"bar2"}'],
             [[], null],
         ];
 

--- a/Tests/Unit/Connection/Handler/RequestSerializationHandlerTest.php
+++ b/Tests/Unit/Connection/Handler/RequestSerializationHandlerTest.php
@@ -41,8 +41,14 @@ class RequestSerializationHandlerTest extends TestCase
         $data = [
             [['http_method' => 'POST', 'body' => ['foo' => 'bar']], '{"foo":"bar"}'],
             [['http_method' => 'GET', 'query_params' => ['foo' => 'bar']], null],
-            [['http_method' => 'POST', 'body' => ['foo' => 'bar'], 'query_params' => ['foo' => 'bar']], '{"foo":"bar"}'],
-            [['http_method' => 'POST', 'body' => ['foo1' => 'bar1'], 'query_params' => ['foo2' => 'bar2']], '{"foo1":"bar1","foo2":"bar2"}'],
+            [
+                ['http_method' => 'POST', 'body' => ['foo' => 'bar'], 'query_params' => ['foo' => 'bar']],
+                '{"foo":"bar"}'
+            ],
+            [
+                ['http_method' => 'POST', 'body' => ['foo1' => 'bar1'], 'query_params' => ['foo2' => 'bar2']],
+                '{"foo1":"bar1","foo2":"bar2"}'
+            ],
             [[], null],
         ];
 


### PR DESCRIPTION
Removed body parameter for GET request, this is required for making requests to CloudFront.